### PR TITLE
Use arguments variable in callback instead of query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ the request to following endpoint.
 To add dynamic values in the REST API definition the operator `:` can be used
 
 ```php
-$server->post('/say/:word', function (\Psr\Http\Message\ServerRequestInterface $request, callable $next, array $arguments) {
-    $word = $arguments['word'];
+$server->post('/say/:word', function (\Psr\Http\Message\ServerRequestInterface $request, callable $next, array $parameters) {
+    $word = $parameters['word'];
 
     return new \React\Http\Response(200, array(), 'You said: ' . $word);
 });
 ```
 
 Now a HTTP client can call the address e.g. `http://localhost:8080/say/hello`.
-The key `word` and value `hello` will be stored in query parameters of the
-PSR-7 request.
+The key `word` and value `hello` will be stored in the third
+parameter of the callback function.
 
 There is no type check her that can validate which API should be used.
 `/say/:word` and`/say/:number` would be the same. In this case the order of your API

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ the request to following endpoint.
 To add dynamic values in the REST API definition the operator `:` can be used
 
 ```php
-$server->post('/say/:word', function (\Psr\Http\Message\ServerRequestInterface $request, callable $next) {
-    $word = $request->getQueryParams()['word'];
+$server->post('/say/:word', function (\Psr\Http\Message\ServerRequestInterface $request, callable $next, array $arguments) {
+    $word = $arguments['word'];
 
     return new \React\Http\Response(200, array(), 'You said: ' . $word);
 });

--- a/examples/01-define-api.php
+++ b/examples/01-define-api.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 $loop = \React\EventLoop\Factory::create();
 

--- a/examples/01-define-api.php
+++ b/examples/01-define-api.php
@@ -10,8 +10,8 @@ $server->get('/say/hello', function (\Psr\Http\Message\ServerRequestInterface $r
     return new \React\Http\Response(200, array(), 'hello');
 });
 
-$server->post('/say/:word', function (\Psr\Http\Message\ServerRequestInterface $request, callable $next) {
-    $word = $request->getQueryParams()['word'];
+$server->post('/say/:word', function (\Psr\Http\Message\ServerRequestInterface $request, callable $next, array $arguments) {
+    $word = $arguments['word'];
 
     return new \React\Http\Response(200, array(), 'You said: ' . $word);
 });

--- a/src/Server.php
+++ b/src/Server.php
@@ -103,19 +103,17 @@ class Server
                     return $next($request);
                 }
 
-                $queryParams = $request->getQueryParams();
+                $argument = array();
 
                 foreach ($pathArray as $id => $valueName) {
                     $position = strpos($valueName, ':');
                     if (0 === $position) {
                         $valueName = substr($valueName, 1);
-                        $queryParams[$valueName] = $requestPathArray[$id];
+                        $argument[$valueName] = $requestPathArray[$id];
                     }
                 }
 
-                $request = $request->withQueryParams($queryParams);
-
-                return $function($request, $next);
+                return $function($request, $next, $argument);
             }
 
             return $next($request);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -59,16 +59,16 @@ class ServerTest extends TestCase
         $this->assertSame('example.com', $requestAssertion->getHeaderLine('Host'));
     }
 
-    public function testCreatePostEndpointOnTestServerAndSendRequestWithQueryParameter()
+    public function testCreatePostEndpointOnTestServerAndSendRequestWithAdditionalParameter()
     {
         $requestAssertion = null;
         $idAssertion = null;
 
         $server = new Server();
 
-        $server->post('/user/add/:id', function (ServerRequestInterface $request, callable $next) use (&$requestAssertion, &$idAssertion) {
+        $server->post('/user/add/:id', function (ServerRequestInterface $request, callable $next, array $paramters) use (&$requestAssertion, &$idAssertion) {
             $requestAssertion = $request;
-            $idAssertion = $request->getQueryParams()['id'];
+            $idAssertion = $paramters['id'];
         });
 
         $server->listen($this->socket);
@@ -86,7 +86,7 @@ class ServerTest extends TestCase
         $this->assertEquals('10', $idAssertion);
     }
 
-    public function testCreatePutEndpointOnTestServerAndSendRequestWithQueryParameters()
+    public function testCreatePutEndpointOnTestServerAndSendRequestWithParameters()
     {
         $requestAssertion = null;
         $idAssertion = null;
@@ -94,10 +94,10 @@ class ServerTest extends TestCase
 
         $server = new Server();
 
-        $server->put('/user/add/:id/group/:name', function (ServerRequestInterface $request, callable $next) use (&$requestAssertion, &$idAssertion, &$nameAssertion) {
+        $server->put('/user/add/:id/group/:name', function (ServerRequestInterface $request, callable $next, array $parameters) use (&$requestAssertion, &$idAssertion, &$nameAssertion) {
             $requestAssertion = $request;
-            $idAssertion = $request->getQueryParams()['id'];
-            $nameAssertion = $request->getQueryParams()['name'];
+            $idAssertion = $parameters['id'];
+            $nameAssertion = $parameters['name'];
         });
 
         $server->listen($this->socket);


### PR DESCRIPTION
This adds an possible third parameter for the callback function defined for the endpoints.

The values will no longer be added as query parameters and therefore no longer be overwritten.